### PR TITLE
docs: update hexo-generator-serach link and lint

### DIFF
--- a/docs/third-party-support.md
+++ b/docs/third-party-support.md
@@ -6,7 +6,7 @@ sidebarDepth: 2
 
 > More third-party libs are coming soon.
 
-------
+---
 
 ## Comments
 
@@ -60,10 +60,10 @@ And then set the `melody.yml`:
 ```yaml
 gitment:
   enable: true # or false
-  owner: your github name 
-  repo: your github repo 
+  owner: your github name
+  repo: your github repo
   client_id: your client id
-  client_secret: your client secret 
+  client_secret: your client secret
 ```
 
 For example:
@@ -73,8 +73,8 @@ gitment:
   enable: true
   owner: Molunerfinn
   repo: Molunerfinn.github.io
-  client_id: xxxx 
-  client_secret: yyyy 
+  client_id: xxxx
+  client_secret: yyyy
 ```
 
 #### Screenshot
@@ -90,7 +90,7 @@ And then set the `melody.yml`:
 ```yaml
 gitalk:
   enable: true
-  client_id: your client id 
+  client_id: your client id
   client_secret: your client secret
   repo: your github repo
   owner: your github name
@@ -110,8 +110,8 @@ And then set the `melody.yml`:
 ```yaml
 valine:
   enable: false # if you want use valine,please set this value is ture
-  appId:  # leancloud application app id
-  appKey:  # leancloud application app key
+  appId: # leancloud application app id
+  appKey: # leancloud application app key
   notify: false # valine mail notify (true/false) https://github.com/xCss/Valine/wiki
   verify: false # valine verify code (true/false)
   pageSize: 10 # comment list page size
@@ -125,7 +125,7 @@ valine:
 
 ![](https://user-images.githubusercontent.com/12621342/37018884-f9e8fc56-2150-11e8-906a-ec0a3f1d1e91.png)
 
-------
+---
 
 ## Share
 
@@ -175,7 +175,7 @@ sharejs:
 
 ![](https://user-images.githubusercontent.com/12621342/34594230-c537c5e8-f20a-11e7-9d52-267f3456aa22.png)
 
-------
+---
 
 ## Search
 
@@ -190,7 +190,6 @@ After set the search system, you will have a global search button in the navbar 
 2. Set the `melody.yml`
 
 ```yaml
-
 algolia_search:
   enable: true # or false
   hits:
@@ -213,7 +212,7 @@ algolia_search:
 
 ### Local search <Badge text="v1.3.0+" />
 
-1. You should install [hexo-generator-search](https://github.com/PaicHyperionDev/hexo-generator-search). Follow its doc to setup. **Only supporting the `xml` file**.
+1. You should install [hexo-generator-search](https://github.com/wzpan/hexo-generator-search). Follow its doc to setup. **Only supporting the `xml` file**.
 
 2. Set the `melody.yml`
 
@@ -229,7 +228,7 @@ local_search:
 
 ![](https://user-images.githubusercontent.com/12621342/34635853-8404ead0-f2d0-11e7-8feb-936dec267523.png)
 
-------
+---
 
 ## Analytics
 
@@ -275,7 +274,7 @@ google_analytics: your code # usually start with `UA-`
 tencent_analytics: your code
 ```
 
-------
+---
 
 ## Adsense
 
@@ -301,7 +300,7 @@ google_adsense:
 
 ![](https://user-images.githubusercontent.com/24741764/44613950-7776f400-a84e-11e8-9fbc-97b3bcaa71e3.png)
 
-------
+---
 
 ## Access Logs (UV/PV)
 
@@ -319,22 +318,22 @@ busuanzi:
   # custom uv span for the whole site
   site_uv: true
   site_uv_header: <i class="fa fa-user"></i>
-  site_uv_footer: 
+  site_uv_footer:
   # custom pv span for the whole site
   site_pv: true
   site_pv_header: <i class="fa fa-eye"></i>
-  site_pv_footer: 
+  site_pv_footer:
   # custom pv span for one page only
   page_pv: true
   page_pv_header: <i class="fa fa-file-o"></i>
-  page_pv_footer: 
+  page_pv_footer:
 ```
 
 #### Screenshot
 
 ![](https://user-images.githubusercontent.com/12621342/34635857-8f6f4032-f2d0-11e7-9cdf-4957d9cc0aa1.png)
 
-------
+---
 
 ## Mathematical formula
 
@@ -401,7 +400,7 @@ And you can customize KaTeX as you want through [`@neilsustc/markdown-it-katex`]
 markdown_it_plus:
   plugins:
     - plugin:
-      name: '@neilsustc/markdown-it-katex'
+      name: "@neilsustc/markdown-it-katex"
       enable: true
       options:
         strict: false
@@ -409,13 +408,13 @@ markdown_it_plus:
 
 Of course, you can define you own `macros` using this feature.
 
-Because KaTeX is faster and lightweight, there are fewer features than MathJax (right-click menu). For those are used to MathJax, we also added [*Copy As TeX Code*](https://github.com/upupming/katex-copytex) support for KaTeX, which is enabled by default.
+Because KaTeX is faster and lightweight, there are fewer features than MathJax (right-click menu). For those are used to MathJax, we also added [_Copy As TeX Code_](https://github.com/upupming/katex-copytex) support for KaTeX, which is enabled by default.
 
 #### Screenshot
 
 <img src=https://user-images.githubusercontent.com/24741764/52897430-47157e80-320f-11e9-821c-ba5517ae096f.gif height=600px>
 
-------
+---
 
 ## Word counting <Badge text="v1.3.0+" />
 

--- a/docs/zh-Hans/third-party-support.md
+++ b/docs/zh-Hans/third-party-support.md
@@ -6,17 +6,17 @@ sidebarDepth: 2
 
 > 更多的第三方支持不断加入中。
 
-------
+---
 
 ## 评论系统
 
 ::: warning
-你只能为你的博客选择一个评论系统。否则theme-melody将会在你开启的两个或者更多的评论系统里选择其中一个。
+你只能为你的博客选择一个评论系统。否则 theme-melody 将会在你开启的两个或者更多的评论系统里选择其中一个。
 :::
 
 ### Disqus
 
-注册[disqus](https://disqus.com/)，配置你自己的disqus，然后在`theme-melody`里开启它。
+注册[disqus](https://disqus.com/)，配置你自己的 disqus，然后在`theme-melody`里开启它。
 
 配置`melody.yml`
 
@@ -43,7 +43,7 @@ laibili:
   uid: 你的laibili的uid
 ```
 
-laibili的uid你能在这里找到:
+laibili 的 uid 你能在这里找到:
 
 ![](https://user-images.githubusercontent.com/12621342/34594229-c4e35800-f20a-11e7-947b-6e0a29537b1e.jpg)
 
@@ -53,17 +53,17 @@ laibili的uid你能在这里找到:
 
 ### Gitment <Badge text="v1.4.0+" />
 
-遵循[gitment](https://github.com/imsun/gitment)的指示去获取你的github Oauth 应用的client id 和 secret值。
+遵循[gitment](https://github.com/imsun/gitment)的指示去获取你的 github Oauth 应用的 client id 和 secret 值。
 
 然后配置`melody.yml`:
 
 ```yaml
 gitment:
   enable: true # or false
-  owner: 你的github用户名 
-  repo: 你的github仓库 
+  owner: 你的github用户名
+  repo: 你的github仓库
   client_id: 你的client id
-  client_secret: 你的client secret 
+  client_secret: 你的client secret
 ```
 
 举例:
@@ -73,45 +73,45 @@ gitment:
   enable: true
   owner: Molunerfinn
   repo: Molunerfinn.github.io
-  client_id: xxxx 
-  client_secret: yyyy 
+  client_id: xxxx
+  client_secret: yyyy
 ```
 
 #### 截图
 
 ![](https://user-images.githubusercontent.com/12621342/34594227-c4240c20-f20a-11e7-8463-64386439207f.jpg)
 
-### Gitalk  <Badge text="v1.4.3+" />
+### Gitalk <Badge text="v1.4.3+" />
 
-遵循[gitalk](https://github.com/gitalk/gitalk)的指示去获取你的github Oauth 应用的client id 和 secret值。以及查看它的相关配置说明。
+遵循[gitalk](https://github.com/gitalk/gitalk)的指示去获取你的 github Oauth 应用的 client id 和 secret 值。以及查看它的相关配置说明。
 
 然后配置`melody.yml`:
 
 ```yaml
 gitalk:
   enable: true
-  client_id: 你的client id 
+  client_id: 你的client id
   client_secret: 你的client secret
   repo: 你的github仓库
   owner: 你的github用户名
   admin: 该仓库的拥有者或协作者
 ```
 
-#### 截图 
+#### 截图
 
 ![](https://user-images.githubusercontent.com/12621342/37018676-34892058-2150-11e8-92a0-62d8ed83896c.png)
 
 ### Valine <Badge text="v1.4.3+" />
 
-遵循[Valine](https://github.com/xCss/Valine)的指示去配置你的LeanCloud应用。以及查看相应的配置说明。
+遵循[Valine](https://github.com/xCss/Valine)的指示去配置你的 LeanCloud 应用。以及查看相应的配置说明。
 
 然后配置`melody.yml`:
 
 ```yaml
 valine:
   enable: false # if you want use valine,please set this value is ture
-  appId:  # leancloud application app id
-  appKey:  # leancloud application app key
+  appId: # leancloud application app id
+  appKey: # leancloud application app key
   notify: false # valine mail notify (true/false) https://github.com/xCss/Valine/wiki
   verify: false # valine verify code (true/false)
   pageSize: 10 # comment list page size
@@ -125,17 +125,17 @@ valine:
 
 ![](https://user-images.githubusercontent.com/12621342/37018884-f9e8fc56-2150-11e8-906a-ec0a3f1d1e91.png)
 
-------
+---
 
 ## 分享系统
 
 ::: warning
-你只能为你的博客选择一个分享系统。否则theme-melody将会在你开启的两个或者更多的分享系统里选择其中一个。
+你只能为你的博客选择一个分享系统。否则 theme-melody 将会在你开启的两个或者更多的分享系统里选择其中一个。
 :::
 
 ### AddThis
 
-> 找到你的pub-id
+> 找到你的 pub-id
 
 ![](https://blog-1251750343.cos.ap-beijing.myqcloud.com/8700af19ly1fjcj0cbbazj21bq0aqwg3.jpg)
 
@@ -175,7 +175,7 @@ sharejs:
 
 ![](https://user-images.githubusercontent.com/12621342/34594230-c537c5e8-f20a-11e7-9d52-267f3456aa22.png)
 
-------
+---
 
 ## 搜索系统
 
@@ -208,7 +208,7 @@ algolia_search:
 
 ### 本地搜索 <Badge text="v1.3.0+" />
 
-1. 你需要安装 [hexo-generator-search](https://github.com/PaicHyperionDev/hexo-generator-search). 根据它的文档去做相应配置。**注意格式只支持xml**。
+1. 你需要安装 [hexo-generator-search](https://github.com/wzpan/hexo-generator-search). 根据它的文档去做相应配置。**注意格式只支持 xml**。
 
 2. Set the `melody.yml`
 
@@ -224,7 +224,7 @@ local_search:
 
 ![](https://blog-1251750343.cos.ap-beijing.myqcloud.com/8700af19ly1fksfyhkvruj21z20ug44m.jpg)
 
-------
+---
 
 ## 分析统计
 
@@ -246,7 +246,7 @@ baidu_analytics: 你的代码
 
 1. 登录谷歌分析的[官方网站](https://www.google.com/analytics/)
 
-2. 找到你的谷歌分析的跟踪ID
+2. 找到你的谷歌分析的跟踪 ID
 
 ![](https://blog-1251750343.cos.ap-beijing.myqcloud.com/8700af19ly1fjckd6djgtj218e05edg2.jpg)
 
@@ -270,7 +270,7 @@ google_analytics: 你的代码 # 通常以`UA-`打头
 tencent_analytics: 你的代码
 ```
 
-------
+---
 
 ## 广告
 
@@ -278,7 +278,7 @@ tencent_analytics: 你的代码
 
 1. 登录谷歌广告的[网站](https://www.google.com/adsense)
 
-2. 添加广告并找到你的client-id, 通常是以`ca-pub-`开头
+2. 添加广告并找到你的 client-id, 通常是以`ca-pub-`开头
 
 ![20190219155033.png](https://i.loli.net/2019/02/19/5c6bb548cb96f.png)
 
@@ -296,13 +296,13 @@ google_adsense:
 
 ![](https://user-images.githubusercontent.com/24741764/44613950-7776f400-a84e-11e8-9fbc-97b3bcaa71e3.png)
 
-------
+---
 
-## 访问日志(UV和PV)
+## 访问日志(UV 和 PV)
 
 ### busuanzi
 
-访问busuanzi的[官方网站](http://busuanzi.ibruce.info/)查看更多的介绍。
+访问 busuanzi 的[官方网站](http://busuanzi.ibruce.info/)查看更多的介绍。
 
 配置`melody.yml`
 
@@ -310,32 +310,32 @@ google_adsense:
 # busuanzi count for PV / UV in site
 busuanzi:
   enable: true
-  # 全站uv 
+  # 全站uv
   site_uv: true
   site_uv_header: <i class="fa fa-user"></i>
-  site_uv_footer: 
+  site_uv_footer:
   # 全站pv
   site_pv: true
   site_pv_header: <i class="fa fa-eye"></i>
-  site_pv_footer: 
+  site_pv_footer:
   # 单独页面pv
   page_pv: true
   page_pv_header: <i class="fa fa-file-o"></i>
-  page_pv_footer: 
+  page_pv_footer:
 ```
 
 #### 截图
 
 ![](https://blog-1251750343.cos.ap-beijing.myqcloud.com/8700af19ly1fjcl0gur6tj21z20a8q4t.jpg)
 
-------
+---
 
 ## 数学公式
 
 ### MathJax
 
 ::: tip
-建议使用KaTex获得更好的效果，下文有介绍！
+建议使用 KaTex 获得更好的效果，下文有介绍！
 :::
 
 配置`melody.yml`:
@@ -346,14 +346,13 @@ mathjax:
   cdn: https://cdn.bootcss.com/mathjax/2.7.2/MathJax.js?config=TeX-AMS-MML_HTMLorMML # required
 ```
 
-然后你需要修改一下默认的`markdown`渲染引擎来实现MathJax的效果。
+然后你需要修改一下默认的`markdown`渲染引擎来实现 MathJax 的效果。
 
 查看: [hexo-renderer-kramed](https://www.npmjs.com/package/hexo-renderer-kramed)
 
-以下操作在你hexo博客的目录下(**不是theme-melody的目录!**):
+以下操作在你 hexo 博客的目录下(**不是 theme-melody 的目录!**):
 
 ![](https://user-images.githubusercontent.com/12621342/41012862-49cd9ed0-6976-11e8-8ef2-28c6b4208aa8.png)
-
 
 #### 截图
 
@@ -361,7 +360,7 @@ mathjax:
 
 ### KaTeX <Badge text="v1.6.0+" />
 
-首先禁用`MathJax`（如果你配置过MathJax的话），然后修改你的`melody.yml`以便加载`katex.min.css`:
+首先禁用`MathJax`（如果你配置过 MathJax 的话），然后修改你的`melody.yml`以便加载`katex.min.css`:
 
 ```yaml
 katex:
@@ -370,7 +369,7 @@ katex:
     css: https://cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.css
 ```
 
-你不需要添加`katex.min.js`来渲染数学方程。相应的你需要卸载你之前的hexo的markdown渲染器以及`hexo-math`，然后安装新的`hexo-renderer-markdown-it-plus`:
+你不需要添加`katex.min.js`来渲染数学方程。相应的你需要卸载你之前的 hexo 的 markdown 渲染器以及`hexo-math`，然后安装新的`hexo-renderer-markdown-it-plus`:
 
 ```bash
 # 替换 `hexo-renderer-kramed` 或者 `hexo-renderer-marked` 等hexo的markdown渲染器
@@ -388,7 +387,7 @@ npm un hexo-math --save
 npm i @upupming/hexo-renderer-markdown-it-plus --save
 ```
 
-注意到 [`hexo-renderer-markdown-it-plus`](https://github.com/CHENXCHEN/hexo-renderer-markdown-it-plus) 已经无人持续维护, 所以我们使用 [`@upupming/hexo-renderer-markdown-it-plus`](https://github.com/upupming/hexo-renderer-markdown-it-plus)。 这份fork的代码使用了 [`@neilsustc/markdown-it-katex`](https://github.com/yzhang-gh/markdown-it-katex) 同时它也是VSCode的插件[Markdown All in One](https://github.com/yzhang-gh/vscode-markdown)所使用的, 所以我们可以获得最新的KaTex功能例如 `\tag{}`。
+注意到 [`hexo-renderer-markdown-it-plus`](https://github.com/CHENXCHEN/hexo-renderer-markdown-it-plus) 已经无人持续维护, 所以我们使用 [`@upupming/hexo-renderer-markdown-it-plus`](https://github.com/upupming/hexo-renderer-markdown-it-plus)。 这份 fork 的代码使用了 [`@neilsustc/markdown-it-katex`](https://github.com/yzhang-gh/markdown-it-katex) 同时它也是 VSCode 的插件[Markdown All in One](https://github.com/yzhang-gh/vscode-markdown)所使用的, 所以我们可以获得最新的 KaTex 功能例如 `\tag{}`。
 
 你还可以通过 [`@neilsustc/markdown-it-katex`](https://github.com/yzhang-gh/markdown-it-katex) 控制 KaTeX 的设置，所有可配置的选项参见 https://katex.org/docs/options.html。 比如你想要禁用掉 KaTeX 在命令行上输出的冗长的警告信息，你可以在根目录的 `_config.yml` 中使用下面的配置将 `strict` 设置为 false:
 
@@ -396,7 +395,7 @@ npm i @upupming/hexo-renderer-markdown-it-plus --save
 markdown_it_plus:
   plugins:
     - plugin:
-      name: '@neilsustc/markdown-it-katex'
+      name: "@neilsustc/markdown-it-katex"
       enable: true
       options:
         strict: false
@@ -404,20 +403,19 @@ markdown_it_plus:
 
 当然，你还可以利用这个特性来定义一些自己常用的 `macros`。
 
-因为KaTeX更快更轻量，因此没有 MathJax 的功能多（比如右键菜单）。为那些使用MathJax的用户，我们也为KaTeX默认添加了 [*Copy As TeX Code*](https://github.com/upupming/katex-copytex) 的功能。
+因为 KaTeX 更快更轻量，因此没有 MathJax 的功能多（比如右键菜单）。为那些使用 MathJax 的用户，我们也为 KaTeX 默认添加了 [_Copy As TeX Code_](https://github.com/upupming/katex-copytex) 的功能。
 
 #### 截图
 
 <img src=https://user-images.githubusercontent.com/24741764/52897430-47157e80-320f-11e9-821c-ba5517ae096f.gif height=600px>
 
-
-------
+---
 
 ## 字数统计 <Badge text="v1.3.0+" />
 
 要为`theme-melody`配上字数统计特性, 你需要如下几个步骤:
 
-1. 打开hexo工作目录
+1. 打开 hexo 工作目录
 2. `npm install hexo-wordcount --save` or `yarn add hexo-wordcount`
 3. 配置`melody.yml`:
 
@@ -426,17 +424,17 @@ wordcount:
   enable: true
 ```
 
-#### 截图 
+#### 截图
 
 ![](https://i.loli.net/2019/04/29/5cc6fe1698a7d.jpg)
 
------
+---
 
 ## 文章置顶 <Badge text="v1.6.0+" />
 
 要为你一些文章置顶，你需要如下步骤:
 
-1. 打开hexo工作目录
+1. 打开 hexo 工作目录
 2. `npm uninstall hexo-generator-index --save` 然后 `npm install hexo-generator-index-pin-top --save`
 3. 你要在文章的`front-matter`区域里添加`top: True`属性来把这篇文章置顶。
 4. 你可以参考[hexo-generator-index-pin-top](https://github.com/netcan/hexo-generator-index-pin-top)这个仓库来了解更多细节。


### PR DESCRIPTION
<https://github.com/PaicHyperionDev/hexo-generator-search> has redirected to <https://github.com/wzpan/hexo-generator-search>.

And when I save it, markdownlint modified some space between words and others.